### PR TITLE
feat: Add Gradio interface to MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,26 @@ Network Experts Team
 
 Each brother specializes in specific network domains while collaborating through SuperAgentX's multi-agent framework.
 
+## Gradio Interface 🖥️
+
+New real-time communication interface available via:
+```bash
+python gradio_interface.py
+```
+
+### Features:
+- Real-time chat with any Network Expert
+- Visual conversation history
+- System status monitoring
+- Ready for Hugging Face Spaces deployment
+
+### Spaces Deployment:
+1. Create new Space on Hugging Face
+2. Set environment variables:
+   - `A2A_SERVER_URL`
+   - `HUGGING_FACE_TOKEN` 
+   - `OPENAI_API_KEY`
+
 ## License
 
 MIT License - See LICENSE file for details.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,11 @@
+from gradio_interface import create_interface
+import os
+
+# Initialize the Gradio interface
+demo = create_interface()
+
+# Configure for Hugging Face Spaces
+if os.environ.get('SPACES') == '1':
+    demo.launch(server_name="0.0.0.0", server_port=7860)
+else:
+    demo.launch()

--- a/gradio_interface.py
+++ b/gradio_interface.py
@@ -1,0 +1,76 @@
+import gradio as gr
+import asyncio
+from core.config import config
+from a2a.protocol import A2AClient, A2AMessage
+
+class GradioInterface:
+    """Real-time A2A communication interface for Hugging Face Spaces"""
+    
+    def __init__(self):
+        self.agents = {
+            "Network Analyst": "agent_analyst",
+            "Security Expert": "agent_security", 
+            "Protocol Specialist": "agent_protocol"
+        }
+        self.a2a = A2AClient(config.a2a_server_url)
+        
+    async def send_message(self, agent, message, history):
+        """Handle message sending and response processing"""
+        try:
+            msg = A2AMessage(
+                sender="human_operator",
+                recipients=[self.agents[agent]],
+                content={
+                    "type": "chat",
+                    "text": message,
+                    "interface": "gradio"
+                }
+            )
+            response = await self.a2a.send(msg)
+            history.append((message, response.content["text"]))
+            return history, ""
+        except Exception as e:
+            return history, f"Error: {str(e)}"
+
+def create_interface():
+    """Build Gradio interface components"""
+    interface = GradioInterface()
+    
+    with gr.Blocks(theme=gr.themes.Soft(), title="Network Experts A2A") as demo:
+        gr.Markdown("## 🤖 Network Experts Communication Hub")
+        gr.Markdown(f"Connected to A2A server: `{config.a2a_server_url}`")
+        
+        with gr.Row():
+            with gr.Column(scale=1):
+                agent = gr.Dropdown(
+                    label="Select Expert Agent",
+                    choices=list(interface.agents.keys()),
+                    value="Network Analyst"
+                )
+                status = gr.Textbox("🟢 System Online", label="Connection Status")
+            
+            with gr.Column(scale=3):
+                chatbot = gr.Chatbot(height=400, label="Conversation")
+                msg = gr.Textbox(label="Your Message", placeholder="Type your query...")
+                send = gr.Button("Send")
+                clear = gr.Button("Clear History")
+        
+        msg.submit(
+            interface.send_message,
+            [agent, msg, chatbot],
+            [chatbot, msg],
+            queue=False
+        )
+        send.click(
+            interface.send_message,
+            [agent, msg, chatbot],
+            [chatbot, msg],
+            queue=False
+        )
+        clear.click(lambda: [], None, chatbot, queue=False)
+    
+    return demo
+
+if __name__ == "__main__":
+    demo = create_interface()
+    demo.queue().launch(server_name="0.0.0.0", server_port=7860)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+gradio>=4.0
+httpx>=0.25.0
+python-dotenv>=1.0.0
+fastapi>=0.95.0
+uvicorn>=0.22.0
+aiohttp>=3.8.0

--- a/tests/test_gradio.py
+++ b/tests/test_gradio.py
@@ -1,0 +1,48 @@
+import pytest
+import asyncio
+from gradio_interface import GradioInterface
+from a2a.protocol import A2AMessage
+
+class TestGradioInterface:
+    @pytest.fixture
+    def interface(self):
+        return GradioInterface()
+
+    @pytest.mark.asyncio
+    async def test_agent_selection(self, interface):
+        assert "Network Analyst" in interface.agents
+        assert interface.agents["Network Analyst"] == "agent_analyst"
+
+    @pytest.mark.asyncio
+    async def test_message_exchange(self, interface, mocker):
+        # Mock A2A client response
+        mock_response = A2AMessage(
+            sender="agent_analyst",
+            recipients=["human_operator"],
+            content={"text": "Analysis started for 192.168.1.0/24"}
+        )
+        mocker.patch.object(interface.a2a, 'send', return_value=mock_response)
+
+        history = []
+        test_msg = "Analyze 192.168.1.0/24 network"
+        
+        history, _ = await interface.send_message(
+            "Network Analyst",
+            test_msg,
+            history
+        )
+        
+        assert len(history) == 1
+        assert history[0][0] == test_msg
+        assert "started" in history[0][1].lower()
+        interface.a2a.send.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_error_handling(self, interface):
+        history = []
+        history, error = await interface.send_message(
+            "Invalid Agent",
+            "Test message",
+            history
+        )
+        assert "Error" in error


### PR DESCRIPTION
## Description
Added Gradio web interface to the MCP server with:
- Real-time monitoring dashboard
- Interactive tool controls
- JSON input/output handling
- Async task management

## Changes
- Created Gradio interface builder
- Integrated with existing MCP tools
- Added proper error handling
- Preserved all existing functionality

## Testing
Manual tests performed:
- [x] MQTT tool execution
- [x] Network scanning
- [x] Error handling

## Screenshots
Gradio interface provides:
- Tool selection dropdowns
- Parameter input forms
- Real-time results display

## Notes
Requires Gradio dependency (added to requirements.txt)

## Summary by Sourcery

Provide a Gradio-based web and chat interface for the MCP server and A2A communication, integrate it into the server startup flow, and update docs, dependencies, and tests accordingly

New Features:
- Introduce a Gradio interface builder in the MCP server for real-time tool control
- Implement a standalone Gradio chat interface for A2A communication compatible with Hugging Face Spaces

Enhancements:
- Integrate Gradio server launch alongside existing SSE and stdio modes with async task management
- Add an app.py entrypoint that conditionally launches the Gradio demo based on environment

Build:
- Add Gradio, HTTPX, python-dotenv, FastAPI, Uvicorn, and aiohttp to project dependencies

Documentation:
- Expand README with Gradio interface usage instructions and Spaces deployment guide

Tests:
- Add pytest coverage for GradioInterface agent selection, message exchange, and error handling